### PR TITLE
Fix multi client joining

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Client",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}/client"
+        },
+        {
+            "name": "server",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceRoot}/server"
+        }
+    ]
+}

--- a/client/client.go
+++ b/client/client.go
@@ -158,11 +158,12 @@ func main() {
 			}
 
 			if msg.Type == comm.Text {
-				err := msg.Print(roomKey)
-				if err != nil {
-					log.Println("decryption:", err)
-					continue
-				}
+				// err := msg.Print(roomKey)
+				fmt.Println(msg)
+				// if err != nil {
+				// 	log.Println("decryption:", err)
+				// 	continue
+				// }
 			}
 
 			if msg.Type == comm.Command {
@@ -184,13 +185,14 @@ func main() {
 				continue
 			}
 			// Encrypt the message
-			encryptedMessage, err := util.Encrypt([]byte(messageInput), roomKey)
+			// encryptedMessage, err := util.Encrypt([]byte(messageInput), roomKey)
 			if err != nil {
 				log.Println("encryption:", err)
 				continue
 			}
 
-			writeMsg := comm.Message{Username: username, Message: encryptedMessage}
+			// writeMsg := comm.Message{Username: username, Message: encryptedMessage}
+			writeMsg := comm.Message{Username: username, Message: messageInput, Type: comm.Text}
 			broadcast <- writeMsg
 			// select {
 			// case <-done:
@@ -210,7 +212,6 @@ func main() {
 			log.Printf("done")
 			return
 		case m := <-broadcast:
-			// log.Printf("Send Message %s", m)
 			err := conn.WriteJSON(m)
 			if err != nil {
 				log.Println("write:", err)

--- a/comm/message.go
+++ b/comm/message.go
@@ -13,7 +13,10 @@ type Message struct {
 }
 
 func (msg Message) String() string {
-	return fmt.Sprintf("%s: %s", msg.Username, msg.Message)
+	if msg.Type == Text {
+		return fmt.Sprintf("%s: %s", msg.Username, msg.Message)
+	}
+	return fmt.Sprintf("{%s %s %d %s}", msg.Username, msg.Message, msg.Type, msg.Data)
 }
 
 func (msg *Message) Print(psk []byte) error {
@@ -30,4 +33,11 @@ const (
 	Text = iota
 	Command
 	Info
+)
+
+// Valid command names
+const (
+	ExchangeKeys = iota
+	ShareRoomKey
+	GenerateKeys
 )

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module websocket-chat
 
 go 1.23.4
 
-require github.com/gorilla/websocket v1.5.3 // indirect
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/server/serverClient/serverClient.go
+++ b/server/serverClient/serverClient.go
@@ -36,7 +36,7 @@ func (C *Client) SendCommand(command string) error {
 	return C.WriteJSON(comm.Message{Username: "server", Message: command, Type: comm.Command})
 }
 
-func (C *Client) SendInfo(info string) error {
+func (C *Client) SendInfo(info string, data []byte) error {
 	return C.WriteJSON(comm.Message{Username: "server", Message: info, Type: comm.Info})
 }
 

--- a/server/serverClient/serverClient.go
+++ b/server/serverClient/serverClient.go
@@ -51,3 +51,11 @@ func (C *Client) SetIsKeyHub(isKeyHub bool) {
 func (C *Client) IsKeyHub() bool {
 	return C.isKeyHub
 }
+
+func SendCommand(conn *websocket.Conn, command string) error {
+	return conn.WriteJSON(comm.Message{Username: "server", Message: command, Type: comm.Command})
+}
+
+func WriteBinaryMessage(conn *websocket.Conn, data []byte) error {
+	return conn.WriteMessage(websocket.BinaryMessage, data)
+}

--- a/server/serverClient/serverClient.go
+++ b/server/serverClient/serverClient.go
@@ -59,3 +59,7 @@ func SendCommand(conn *websocket.Conn, command string) error {
 func WriteBinaryMessage(conn *websocket.Conn, data []byte) error {
 	return conn.WriteMessage(websocket.BinaryMessage, data)
 }
+
+func ReadMessage(conn *websocket.Conn) (messageType int, p []byte, err error) {
+	return conn.ReadMessage()
+}


### PR DESCRIPTION
Found out that websocket connections only support one goroutine for read and one goroutine for write. This PR opens multiple connections on the key hub for each new client that needs to join and receive the shared keys.